### PR TITLE
Use markdown parser to handle code blocks properly

### DIFF
--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -36,12 +36,17 @@ func TestPlugin(t *testing.T) {
 	}
 }
 
-func TestCodeBlock(t *testing.T) {
-
+func TestSpecialCases(t *testing.T) {
 	links := make([]*Link, 0)
 	links = append(links, &Link{
 		Pattern:  "(Mattermost)",
 		Template: "[Mattermost](https://mattermost.com)",
+	}, &Link{
+		Pattern:  "(Example)",
+		Template: "[Example](https://example.com)",
+	}, &Link{
+		Pattern:  "(foobar)",
+		Template: "fb",
 	})
 	validConfiguration := Configuration{links}
 
@@ -128,6 +133,58 @@ func TestCodeBlock(t *testing.T) {
 		{
 			"```\n` Mattermost `\n```\nMattermost",
 			"```\n` Mattermost `\n```\n[Mattermost](https://mattermost.com)",
+		},
+		{
+			"  Mattermost",
+			"  [Mattermost](https://mattermost.com)",
+		},
+		{
+			"    Mattermost",
+			"    Mattermost",
+		},
+		{
+			"    ```\nMattermost\n    ```",
+			"    ```\n[Mattermost](https://mattermost.com)\n    ```",
+		},
+		{
+			"` ``` `\nMattermost\n` ``` `",
+			"` ``` `\n[Mattermost](https://mattermost.com)\n` ``` `",
+		},
+		{
+			"Mattermost \n Mattermost",
+			"[Mattermost](https://mattermost.com) \n [Mattermost](https://mattermost.com)",
+		},
+		{
+			"[Mattermost](https://mattermost.com)",
+			"[Mattermost](https://mattermost.com)",
+		},
+		{
+			"[  Mattermost  ](https://mattermost.com)",
+			"[  Mattermost  ](https://mattermost.com)",
+		},
+		{
+			"[  Mattermost  ][1]\n\n[1]: https://mattermost.com",
+			"[  Mattermost  ][1]\n\n[1]: https://mattermost.com",
+		},
+		{
+			"![  Mattermost  ](https://mattermost.com/example.png)",
+			"![  Mattermost  ](https://mattermost.com/example.png)",
+		},
+		{
+			"![  Mattermost  ][1]\n\n[1]: https://mattermost.com/example.png",
+			"![  Mattermost  ][1]\n\n[1]: https://mattermost.com/example.png",
+		},
+		{
+			"foobar\nExample\nfoobar Mattermost",
+			"fb\n[Example](https://example.com)\nfb [Mattermost](https://mattermost.com)",
+		},
+		{
+			"foobar",
+			"fb",
+		},
+		{
+			"foobarfoobar",
+			"foobarfoobar",
 		},
 	}
 


### PR DESCRIPTION
This fixes #7 and fixes #11.

Important: I did not do the `dep update` here since it would add noise to the PR and I don't know whether you usually include this in a PR or rather do it manually before merging a PR requiring more recent server code. It is nonetheless required for my changes to work as the currently vendorized server code does not contain my change from mattermost/mattermost-server#9067

Once mattermost/mattermost-server#9112 has been merged, the `foobar` in the tests should be replaced with `foo!bar` to ensure everything it works for a string that is currently split over multiple text nodes.