### PR TITLE
Support autolinks and post updates

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -41,9 +41,7 @@ func (p *Plugin) OnConfigurationChange() error {
 	return nil
 }
 
-// MessageWillBePosted is invoked when a message is posted by a user before it is committed
-// to the database.
-func (p *Plugin) MessageWillBePosted(c *plugin.Context, post *model.Post) (*model.Post, string) {
+func (p *Plugin) processPost(c *plugin.Context, post *model.Post) (*model.Post, string) {
 	links := p.links.Load().([]*AutoLinker)
 	postText := post.Message
 	offset := 0
@@ -83,4 +81,16 @@ func (p *Plugin) MessageWillBePosted(c *plugin.Context, post *model.Post) (*mode
 	post.Message = postText
 
 	return post, ""
+}
+
+// MessageWillBePosted is invoked when a message is posted by a user before it is committed
+// to the database.
+func (p *Plugin) MessageWillBePosted(c *plugin.Context, post *model.Post) (*model.Post, string) {
+	return p.processPost(c, post)
+}
+
+// MessageWillBeUpdated is invoked when a message is updated by a user before it is committed
+// to the database.
+func (p *Plugin) MessageWillBeUpdated(c *plugin.Context, post *model.Post, _ *model.Post) (*model.Post, string) {
+	return p.processPost(c, post)
 }

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -47,6 +47,11 @@ func TestSpecialCases(t *testing.T) {
 		Pattern:  "https://mattermost.atlassian.net/browse/MM-(?P<jira_id>\\d+)",
 		Template: "[MM-$jira_id](https://mattermost.atlassian.net/browse/MM-$jira_id)",
 	}, &Link{
+		Pattern:  "MM-(?P<jira_id>\\d+)",
+		Template: "[MM-$jira_id](https://mattermost.atlassian.net/browse/MM-$jira_id)",
+		DisableNonWordPrefix: true,
+		DisableNonWordSuffix: true,
+	}, &Link{
 		Pattern:  "(Example)",
 		Template: "[Example](https://example.com)",
 	}, &Link{
@@ -157,6 +162,12 @@ func TestSpecialCases(t *testing.T) {
 		}, {
 			"Please check https://mattermost.atlassian.net/browse/MM-123 for details",
 			"Please check [MM-123](https://mattermost.atlassian.net/browse/MM-123) for details",
+		}, {
+			"Please check MM-123 for details",
+			"Please check [MM-123](https://mattermost.atlassian.net/browse/MM-123) for details",
+		}, {
+			"Please check the ticket (MM-123) for details",
+			"Please check the ticket ([MM-123](https://mattermost.atlassian.net/browse/MM-123)) for details",
 		}, {
 			"foo!bar\nExample\nfoo!bar Mattermost",
 			"fb\n[Example](https://example.com)\nfb [Mattermost](https://mattermost.com)",

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -38,8 +38,14 @@ func TestPlugin(t *testing.T) {
 func TestSpecialCases(t *testing.T) {
 	links := make([]*Link, 0)
 	links = append(links, &Link{
+		Pattern:  "https://mattermost.com",
+		Template: "[the mattermost portal](https://mattermost.com)",
+	}, &Link{
 		Pattern:  "(Mattermost)",
 		Template: "[Mattermost](https://mattermost.com)",
+	}, &Link{
+		Pattern:  "https://mattermost.atlassian.net/browse/MM-(?P<jira_id>\\d+)",
+		Template: "[MM-$jira_id](https://mattermost.atlassian.net/browse/MM-$jira_id)",
 	}, &Link{
 		Pattern:  "(Example)",
 		Template: "[Example](https://example.com)",
@@ -145,6 +151,12 @@ func TestSpecialCases(t *testing.T) {
 		}, {
 			"![  Mattermost  ][1]\n\n[1]: https://mattermost.com/example.png",
 			"![  Mattermost  ][1]\n\n[1]: https://mattermost.com/example.png",
+		}, {
+			"Why not visit https://mattermost.com?",
+			"Why not visit [the mattermost portal](https://mattermost.com)?",
+		}, {
+			"Please check https://mattermost.atlassian.net/browse/MM-123 for details",
+			"Please check [MM-123](https://mattermost.atlassian.net/browse/MM-123) for details",
 		}, {
 			"foo!bar\nExample\nfoo!bar Mattermost",
 			"fb\n[Example](https://example.com)\nfb [Mattermost](https://mattermost.com)",

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -171,5 +171,9 @@ func TestSpecialCases(t *testing.T) {
 		rpost, _ := p.MessageWillBePosted(&plugin.Context{}, post)
 
 		assert.Equal(t, tt.expectedMessage, rpost.Message)
+
+		upost, _ := p.MessageWillBeUpdated(&plugin.Context{}, post, post)
+
+		assert.Equal(t, tt.expectedMessage, upost.Message)
 	}
 }


### PR DESCRIPTION
I believe this will fix issues #26 and #36.

There is one TODO in there which is not critical: if the raw text contains www.somewhere.com, an autolink is created with destination http://www.somewhere.com, and the plugin logs an error because the destination text and original text don't match (and no replacements are applied). This behaviour is acceptable I think but better to suppress the warning.
