### PR TITLE
Rename "Auto Link" plugin to "Autolink"

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "mattermost-autolink",
-  "name": "Auto Link",
+  "name": "Autolink",
   "description": "Automatically rewrite text matching a regular expression into a markdown link.",
   "version": "0.5.1",
   "server": {


### PR DESCRIPTION
By definition, "An autolink is a hyperlink added automatically to a hypermedia document, after it has been authored or published".  Another definition refers to autolink as automated hyperlinking.

Hence, propose naming the plugin "Autolink" instead of "Auto Link"