### PR TITLE
MM-15965: cleaned up word boundary checks

### DIFF
--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -1,0 +1,1 @@
+settings.json

--- a/server/autolinker.go
+++ b/server/autolinker.go
@@ -7,49 +7,40 @@ import (
 
 // AutoLinker helper for replace regex with links
 type AutoLinker struct {
-	link    *Link
-	pattern *regexp.Regexp
+	link *Link
+	re   *regexp.Regexp
 }
 
 // NewAutoLinker create and initialize a AutoLinker
-func NewAutoLinker(link *Link) (*AutoLinker, error) {
-	if link == nil || len(link.Pattern) == 0 || len(link.Template) == 0 {
+func NewAutoLinker(link Link) (*AutoLinker, error) {
+	if len(link.Pattern) == 0 || len(link.Template) == 0 {
 		return nil, errors.New("Pattern or template was empty")
 	}
 
 	if !link.DisableNonWordPrefix {
-		link.Pattern = "(?P<MMDisableNonWordPrefix>^|\\s)" + link.Pattern
-		link.Template = "${MMDisableNonWordPrefix}" + link.Template
+		link.Pattern = `\b` + link.Pattern
 	}
 
 	if !link.DisableNonWordSuffix {
-		link.Pattern = link.Pattern + "(?P<DisableNonWordSuffix>$|\\s|\\.|\\!|\\?|\\,|\\))"
-		link.Template = link.Template + "${DisableNonWordSuffix}"
+		link.Pattern = link.Pattern + `\b`
 	}
 
-	p, err := regexp.Compile(link.Pattern)
+	re, err := regexp.Compile(link.Pattern)
 	if err != nil {
 		return nil, err
 	}
 
 	return &AutoLinker{
-		link:    link,
-		pattern: p,
+		link: &link,
+		re:   re,
 	}, nil
 }
 
 // Replace will subsitute the regex's with the supplied links
 func (l *AutoLinker) Replace(message string) string {
-	if l.pattern == nil {
+	if l.re == nil {
 		return message
 	}
 
-	// beacuse MMDisableNonWordPrefix DisableNonWordSuffix are greedy then
-	// two matches back to back won't get found.  So we need to run the
-	// replace all twice
-	if !l.link.DisableNonWordPrefix && !l.link.DisableNonWordSuffix {
-		message = string(l.pattern.ReplaceAll([]byte(message), []byte(l.link.Template)))
-	}
-
-	return string(l.pattern.ReplaceAll([]byte(message), []byte(l.link.Template)))
+	return l.re.ReplaceAllString(message, l.link.Template)
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -28,7 +28,7 @@ func (p *Plugin) OnConfigurationChange() error {
 	links := make([]*AutoLinker, 0)
 
 	for _, l := range c.Links {
-		al, lerr := NewAutoLinker(l)
+		al, lerr := NewAutoLinker(*l)
 		if lerr != nil {
 			mlog.Error("Error creating autolinker: ")
 		}


### PR DESCRIPTION
- Using `\b` instead of a homebrewed word separator list
- Since `\b` does not consume, removed the second pass ReplaceAll
- Made tests more realistic by running MessageWillBePosted,
  to cover markdown inspection
- Added word boundary tests
- Cleanup