### PR TITLE
Add `/autolink import/export` commands

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -281,7 +281,7 @@ func executeHelp(p *Plugin, c *plugin.Context, header *model.CommandArgs, args .
 }
 
 func executeExport(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
-	config, err := json.MarshalIndent(p.API.GetConfig().PluginSettings.Plugins["mattermost-autolink"], "", "    ")
+	config, err := json.MarshalIndent(p.getConfig(), "", "    ")
 
 	if err != nil {
 		return responsef(err.Error())

--- a/server/command.go
+++ b/server/command.go
@@ -330,7 +330,7 @@ func executeExport(p *Plugin, c *plugin.Context, header *model.CommandArgs, args
 		return responsef(postErr.Error())
 	}
 
-	return responsef("Exported `autolink-config.json`")
+	return responsef("Exported `" + file.Name + "`")
 }
 
 func responsef(format string, args ...interface{}) *model.CommandResponse {

--- a/server/command.go
+++ b/server/command.go
@@ -284,21 +284,23 @@ func executeHelp(p *Plugin, c *plugin.Context, header *model.CommandArgs, args .
 }
 
 func executeImport(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
-	posts, postsErr := p.API.GetPostsForChannel(header.ChannelId, 0, 1)
-	if postsErr != nil {
-		return responsef(postsErr.Error())
+	posts, err := p.API.GetPostsForChannel(header.ChannelId, 0, 1)
+	if err != nil {
+		return responsef(err.Error())
 	}
 
 	fileID := posts.ToSlice()[0].FileIds[0]
 
-	file, fileErr := p.API.GetFile(fileID)
-	if fileErr != nil {
-		return responsef(fileErr.Error())
+	var file []byte
+	file, err = p.API.GetFile(fileID)
+	if err != nil {
+		return responsef(err.Error())
 	}
 
-	info, infoErr := p.API.GetFileInfo(fileID)
-	if infoErr != nil {
-		return responsef(infoErr.Error())
+	var info *model.FileInfo
+	info, err = p.API.GetFileInfo(fileID)
+	if err != nil {
+		return responsef(err.Error())
 	}
 
 	var config Config

--- a/server/command.go
+++ b/server/command.go
@@ -22,7 +22,7 @@ const helpText = "###### Mattermost Autolink Plugin Administration\n" +
 	"* `/autolink set <linkref> <field> value...` - sets a link's field to a value. The entire command line after <field> is used for the value, unescaped, leading/trailing whitespace trimmed.\n" +
 	"* `/autolink test <linkref> test-text...` - test a link on a sample.\n" +
 	"* `/autolink import` - imports the Autolink configuration file uploaded in the previous post\n" +
-	"* `/autolink export` - exports the Autolink configuration as `autolink-config.json` file to the current channel\n" +
+	"* `/autolink export` - exports the Autolink configuration as `autolink-config.json` to the current channel\n" +
 	"\n" +
 	"Example:\n" +
 	"```\n" +

--- a/server/command.go
+++ b/server/command.go
@@ -21,8 +21,8 @@ const helpText = "###### Mattermost Autolink Plugin Administration\n" +
 	"* `/autolink list` - list all configured links.\n" +
 	"* `/autolink set <linkref> <field> value...` - sets a link's field to a value. The entire command line after <field> is used for the value, unescaped, leading/trailing whitespace trimmed.\n" +
 	"* `/autolink test <linkref> test-text...` - test a link on a sample.\n" +
-	"* `/autolink import` - imports the `autolink-config.json` file uploaded in the previous post\n" +
-	"* `/autolink export` - exports the `autolink-config.json` file to the current channel\n" +
+	"* `/autolink import` - imports the autolink configuration file uploaded in the previous post\n" +
+	"* `/autolink export` - exports the autolink configuration as `autolink-config.json` file to the current channel\n" +
 	"\n" +
 	"Example:\n" +
 	"```\n" +

--- a/server/command.go
+++ b/server/command.go
@@ -307,7 +307,9 @@ func executeImport(p *Plugin, c *plugin.Context, header *model.CommandArgs, args
 		return responsef(configErr.Error())
 	}
 
-	p.conf = config
+	p.updateConfig(func(conf *Config) {
+		*conf = config
+	})
 
 	return responsef("Imported `" + info.Name + "`")
 }

--- a/server/command.go
+++ b/server/command.go
@@ -291,14 +291,12 @@ func executeImport(p *Plugin, c *plugin.Context, header *model.CommandArgs, args
 
 	fileID := posts.ToSlice()[0].FileIds[0]
 
-	var file []byte
-	file, err = p.API.GetFile(fileID)
+	file, err := p.API.GetFile(fileID)
 	if err != nil {
 		return responsef(err.Error())
 	}
 
-	var info *model.FileInfo
-	info, err = p.API.GetFileInfo(fileID)
+	info, err := p.API.GetFileInfo(fileID)
 	if err != nil {
 		return responsef(err.Error())
 	}

--- a/server/command.go
+++ b/server/command.go
@@ -319,11 +319,13 @@ func executeImport(p *Plugin, c *plugin.Context, header *model.CommandArgs, args
 func executeExport(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
 	config, _ := json.MarshalIndent(p.getConfig(), "", "    ")
 	info, _ := p.API.UploadFile(config, header.ChannelId, "autolink-config.json")
+	channel, _ := p.API.GetChannel(header.ChannelId)
 
 	_, err := p.API.CreatePost(&model.Post{
 		UserId:    header.UserId,
 		ChannelId: header.ChannelId,
 		FileIds:   []string{info.Id},
+		Message:   "Autolink config file `" + info.Name + "` exported to channel \"" + channel.DisplayName + "\".",
 	})
 	if err != nil {
 		return responsef(err.Error())

--- a/server/command.go
+++ b/server/command.go
@@ -21,6 +21,8 @@ const helpText = "###### Mattermost Autolink Plugin Administration\n" +
 	"* `/autolink list` - list all configured links.\n" +
 	"* `/autolink set <linkref> <field> value...` - sets a link's field to a value. The entire command line after <field> is used for the value, unescaped, leading/trailing whitespace trimmed.\n" +
 	"* `/autolink test <linkref> test-text...` - test a link on a sample.\n" +
+	"* `/autolink import` - imports the `autolink-config.json` file uploaded in the previous post\n" +
+	"* `/autolink export` - exports the `autolink-config.json` file to the current channel\n" +
 	"\n" +
 	"Example:\n" +
 	"```\n" +

--- a/server/command.go
+++ b/server/command.go
@@ -311,26 +311,19 @@ func executeImport(p *Plugin, c *plugin.Context, header *model.CommandArgs, args
 }
 
 func executeExport(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
-	config, configErr := json.MarshalIndent(p.getConfig(), "", "    ")
-	if configErr != nil {
-		return responsef(configErr.Error())
-	}
+	config, _ := json.MarshalIndent(p.getConfig(), "", "    ")
+	info, _ := p.API.UploadFile(config, header.ChannelId, "autolink-config.json")
 
-	file, fileErr := p.API.UploadFile(config, header.ChannelId, "autolink-config.json")
-	if fileErr != nil {
-		return responsef(fileErr.Error())
-	}
-
-	_, postErr := p.API.CreatePost(&model.Post{
+	_, err := p.API.CreatePost(&model.Post{
 		UserId:    header.UserId,
 		ChannelId: header.ChannelId,
-		FileIds:   []string{file.Id},
+		FileIds:   []string{info.Id},
 	})
-	if postErr != nil {
-		return responsef(postErr.Error())
+	if err != nil {
+		return responsef(err.Error())
 	}
 
-	return responsef("Exported `" + file.Name + "`")
+	return responsef("Exported `" + info.Name + "`")
 }
 
 func responsef(format string, args ...interface{}) *model.CommandResponse {

--- a/server/command.go
+++ b/server/command.go
@@ -21,8 +21,8 @@ const helpText = "###### Mattermost Autolink Plugin Administration\n" +
 	"* `/autolink list` - list all configured links.\n" +
 	"* `/autolink set <linkref> <field> value...` - sets a link's field to a value. The entire command line after <field> is used for the value, unescaped, leading/trailing whitespace trimmed.\n" +
 	"* `/autolink test <linkref> test-text...` - test a link on a sample.\n" +
-	"* `/autolink import` - imports the autolink configuration file uploaded in the previous post\n" +
-	"* `/autolink export` - exports the autolink configuration as `autolink-config.json` file to the current channel\n" +
+	"* `/autolink import` - imports the Autolink configuration file uploaded in the previous post\n" +
+	"* `/autolink export` - exports the Autolink configuration as `autolink-config.json` file to the current channel\n" +
 	"\n" +
 	"Example:\n" +
 	"```\n" +

--- a/server/command.go
+++ b/server/command.go
@@ -289,14 +289,17 @@ func executeImport(p *Plugin, c *plugin.Context, header *model.CommandArgs, args
 		return responsef(err.Error())
 	}
 
-	fileID := posts.ToSlice()[0].FileIds[0]
+	previous := posts.ToSlice()[0]
+	if len(previous.FileIds) == 0 {
+		return responsef("Error: config file not uploaded as attachment in previous post")
+	}
 
-	file, err := p.API.GetFile(fileID)
+	file, err := p.API.GetFile(previous.FileIds[0])
 	if err != nil {
 		return responsef(err.Error())
 	}
 
-	info, err := p.API.GetFileInfo(fileID)
+	info, err := p.API.GetFileInfo(previous.FileIds[0])
 	if err != nil {
 		return responsef(err.Error())
 	}

--- a/server/command.go
+++ b/server/command.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -50,6 +51,7 @@ var autolinkCommandHandler = CommandHandler{
 		"add":     executeAdd,
 		"set":     executeSet,
 		"test":    executeTest,
+		"export":  executeExport,
 	},
 	defaultHandler: executeHelp,
 }
@@ -276,6 +278,16 @@ func executeAdd(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ..
 
 func executeHelp(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
 	return responsef(helpText)
+}
+
+func executeExport(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {
+	config, err := json.MarshalIndent(p.API.GetConfig().PluginSettings.Plugins["mattermost-autolink"], "", "    ")
+
+	if err != nil {
+		return responsef(err.Error())
+	}
+
+	return responsef("```\n" + string(config) + "```")
 }
 
 func responsef(format string, args ...interface{}) *model.CommandResponse {

--- a/server/command.go
+++ b/server/command.go
@@ -307,14 +307,14 @@ func executeImport(p *Plugin, c *plugin.Context, header *model.CommandArgs, args
 	var config Config
 	configErr := json.Unmarshal(file, &config)
 	if configErr != nil {
-		return responsef("Error: `" + info.Name + "` is not a valid Autolink config file")
+		return responsef("Error: `%s` is not a valid Autolink config file", info.Name)
 	}
 
 	p.updateConfig(func(conf *Config) {
 		*conf = config
 	})
 
-	return responsef("Imported `" + info.Name + "`")
+	return responsef("Imported `%s`", info.Name)
 }
 
 func executeExport(p *Plugin, c *plugin.Context, header *model.CommandArgs, args ...string) *model.CommandResponse {

--- a/server/command.go
+++ b/server/command.go
@@ -307,7 +307,7 @@ func executeImport(p *Plugin, c *plugin.Context, header *model.CommandArgs, args
 	var config Config
 	configErr := json.Unmarshal(file, &config)
 	if configErr != nil {
-		return responsef(configErr.Error())
+		return responsef("Error: `" + info.Name + "` is not a valid Autolink config file")
 	}
 
 	p.updateConfig(func(conf *Config) {


### PR DESCRIPTION
Enables importing and exporting config files using the following Autolink commands:

- `/autolink import` - imports the Autolink configuration file uploaded in the previous post
- `/autolink export` - exports the Autolink configuration as `autolink-config.json` to the current channel

Closes #73 