### PR TITLE
[GH-84] Add the concept of plugin admins

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -32,7 +32,7 @@
         "key": "PluginAdmins",
         "display_name": "Admin User IDs",
         "type": "text",
-        "help_text": "Comma-separated list of userIds of users authorized to administer the plugin in addition to the System Admins.\n \nUser IDs can be found by navigating to **System Console** > **Users**. After clicking into a user's name, their ID is on the right-hand side of the blue header."
+        "help_text": "Comma-separated list of userIDs authorized to administer the plugin in addition to the System Admins.\n \nUser IDs can be found by navigating to **System Console** > **Users**."
       }
     ]
   }

--- a/plugin.json
+++ b/plugin.json
@@ -27,6 +27,12 @@
         "display_name": "Apply plugin to updated posts as well as new posts",
         "type": "bool",
         "default": false
+      },
+      {
+        "key": "PluginAdmins",
+        "display_name": "Admin User IDs",
+        "type": "text",
+        "help_text": "Comma-separated list of userIds of users authorized to administer the plugin in addition to the System Admins.\n \nUser IDs can be found by navigating to **System Console** > **Users**. After clicking into a user's name, their ID is on the right-hand side of the blue header."
       }
     ]
   }

--- a/server/autolink/autolink_test.go
+++ b/server/autolink/autolink_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func setupTestPlugin(t *testing.T, l autolink.Autolink) *autolinkplugin.Plugin {
-	p := &autolinkplugin.Plugin{}
+	p := autolinkplugin.New()
 	api := &plugintest.API{}
 
 	api.On("GetChannel", mock.AnythingOfType("string")).Run(func(args mock.Arguments) {

--- a/server/autolinkplugin/command.go
+++ b/server/autolinkplugin/command.go
@@ -66,17 +66,19 @@ func (ch CommandHandler) Handle(p *Plugin, c *plugin.Context, header *model.Comm
 }
 
 func (p *Plugin) ExecuteCommand(c *plugin.Context, commandArgs *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
-	user, appErr := p.API.GetUser(commandArgs.UserId)
-	if appErr != nil {
-		return responsef("%v", appErr.Error()), nil
+	isAdmin, err := p.IsAuthorizedAdmin(commandArgs.UserId)
+	if err != nil {
+		return responsef("error occured while authorizing the command: %v", err), nil
 	}
-	if !strings.Contains(user.Roles, "system_admin") {
-		return responsef("`/autolink` can only be executed by a system administrator."), nil
+	if !isAdmin {
+		return responsef("`/autolink` commands can only be executed by a system administrator or `autolink` plugin admins."), nil
 	}
+
 	args := strings.Fields(commandArgs.Command)
 	if len(args) == 0 || args[0] != "/autolink" {
 		return responsef(helpText), nil
 	}
+
 	return autolinkCommandHandler.Handle(p, c, commandArgs, args[1:]...), nil
 }
 

--- a/server/autolinkplugin/config.go
+++ b/server/autolinkplugin/config.go
@@ -37,7 +37,7 @@ func (p *Plugin) OnConfigurationChange() error {
 		}
 	}
 
-	// NOTE(prozlach): Plugin admin UserId parsing and validation errors are
+	// Plugin admin UserId parsing and validation errors are
 	// not fatal, if everything fails only sysadmin will be able to manage the
 	// config which is still OK
 	c.parsePluginAdminList(p)
@@ -131,9 +131,9 @@ func (conf *Config) parsePluginAdminList(p *Plugin) {
 		return
 	}
 
-	split := strings.Split(conf.PluginAdmins, ",")
+	userIDs := strings.Split(conf.PluginAdmins, ",")
 
-	for _, v := range split {
+	for _, v := range userIDs {
 		userId := strings.TrimSpace(v)
 		// Let's verify that the given user really exists
 		_, appErr := p.API.GetUser(userId)

--- a/server/autolinkplugin/config.go
+++ b/server/autolinkplugin/config.go
@@ -107,7 +107,7 @@ func (conf *Config) ToConfig() map[string]interface{} {
 	return map[string]interface{}{
 		"EnableAdminCommand": conf.EnableAdminCommand,
 		"EnableOnUpdate":     conf.EnableOnUpdate,
-		"AdminUsers":         conf.PluginAdmins,
+		"PluginAdmins":       conf.PluginAdmins,
 		"Links":              links,
 	}
 }

--- a/server/main.go
+++ b/server/main.go
@@ -6,5 +6,5 @@ import (
 )
 
 func main() {
-	plugin.ClientMain(&autolinkplugin.Plugin{})
+	plugin.ClientMain(autolinkplugin.New())
 }


### PR DESCRIPTION
#### Summary
This plugin adds the concept of plugin admin users. A new plugin configuratoin option was added which lists comma-separated usernames for which modifying the configuration of the plugin is allowed (no auto-compleate, see [3]). Please see below for the sample config window:

![autolink_preview](https://user-images.githubusercontent.com/2124609/74608419-10ec3280-50e1-11ea-9689-cdabb4e897ed.png)

and sample interaction with the plugin as a user who first did not have admin privileges, and then was granted ones:

![autolink-error-non-admin](https://user-images.githubusercontent.com/2124609/74608428-2c573d80-50e1-11ea-90c1-03dc4eb397e4.png)

While working on this change I have also changed how the `Config` is handled/passed around. In Go, function arguments are passed by value [1], so if. e.g. the underlying array of the `Config.Links` changed (i.e. new entries were added, causing reallocation), the other copies would be still using the old underlying array which could lead to weird errors. Also, based on the plugin template[2], the thread-safety seems to be guaranteed by passing around the reference to the plugin's config, so that if one goroutine updates the config, the other still has the consistent view on the old configuration as it is holding the old reference. Happy to discuss!

Do we still need `EnableAdminCommand` config option in this plugin, now that we have plugin administrators? Do we want to allow also adding userIds in the new field?

[1] https://stackoverflow.com/a/47486724
[2] https://github.com/mattermost/mattermost-plugin-starter-template/blob/282a8cf227849a25e306caff11597a0e4ba4cd01/server/configuration.go
[3] https://github.com/mattermost/mattermost-plugin-autolink/issues/84#issuecomment-584928588

#### Ticket Link
  Fixes ~~https://github.com/mattermost/mattermost-server/issues/84~~ 
  Fixes https://github.com/mattermost/mattermost-plugin-autolink/issues/84  (jfrerich 2/28/20)