### PR TITLE
[GH-84] Do not rewrite messages from bots

### DIFF
--- a/server/autolink/autolink_test.go
+++ b/server/autolink/autolink_test.go
@@ -25,6 +25,12 @@ func setupTestPlugin(t *testing.T, l autolink.Autolink) *autolinkplugin.Plugin {
 		TeamId: "theteam_id0123456789012345",
 		Name:   "thechannel_name",
 	}, (*model.AppError)(nil))
+
+	testUser := model.User{
+		IsBot: false,
+	}
+	api.On("GetUser", mock.AnythingOfType("string")).Return(&testUser, nil)
+
 	p.SetAPI(api)
 
 	err := l.Compile()

--- a/server/autolinkplugin/plugin_test.go
+++ b/server/autolinkplugin/plugin_test.go
@@ -532,7 +532,7 @@ func TestBotMessagesAreRewritenWhenGetUserFails(t *testing.T) {
 	}
 	api.On("GetUser", mock.AnythingOfType("string")).Return(nil, err).Once()
 
-	p := Plugin{}
+	p := New()
 	p.SetAPI(api)
 	p.OnConfigurationChange()
 
@@ -572,7 +572,7 @@ func TestGetUserApiCallIsNotExecutedWhenThereAreNoChanges(t *testing.T) {
 	api.On("GetTeam", mock.AnythingOfType("string")).Return(&testTeam, nil).Once()
 	api.On("LogDebug", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"))
 
-	p := Plugin{}
+	p := New()
 	p.SetAPI(api)
 	p.OnConfigurationChange()
 
@@ -616,7 +616,7 @@ func TestBotMessagesAreNotRewriten(t *testing.T) {
 	api.On("GetUser", mock.AnythingOfType("string")).Return(&testUser, nil).Once()
 	api.On("LogDebug", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"))
 
-	p := Plugin{}
+	p := New()
 	p.SetAPI(api)
 	p.OnConfigurationChange()
 


### PR DESCRIPTION
#### Summary

This PR makes autolink plugin not rewrite messages from other bots as discussed in https://github.com/mattermost/mattermost-plugin-autolink/issues/94

#### Ticket Link

  Fixes https://github.com/mattermost/mattermost-plugin-autolink/issues/94


