### PR TITLE
Add preconfigured Autolinks to plugin config

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -27,6 +27,41 @@
         "display_name": "Apply plugin to updated posts as well as new posts",
         "type": "bool",
         "default": false
+      },
+      {
+        "key": "EnableMasterCard",
+        "display_name": "MasterCard",
+        "type": "dropdown",
+        "help_text": "Conceal Mastercard Entries",
+        "default": "disabled",
+        "options": [{
+            "display_name": "disabled",
+            "value": "disabled" 
+        }, {
+            "display_name": "enabled",
+            "value": "Pattern: (?P<MasterCard](term>([Cc]ustomer [Oo]bsession)(?P<part1>5[1-5]\\d{2})[ -]?(?P<part2>\\d{4})[ -]?(?P<part3>\\d{4})[ -]?(?P<LastFour>[0-9]{4})) Template: MasterCard XXXX-XXXX-XXXX-$LastFour WordMatch: true"
+        }]
+      },
+      {
+        "key": "EnableMasterCardOld",
+        "display_name": "MasterCard",
+        "help_text": "Conceal Mastercard Entries",
+        "type": "bool",
+        "default": false
+      },
+      {
+        "key": "EnableVisaCard",
+        "display_name": "Visa Card",
+        "help_text": "Conceal Visa Card Entries",
+        "type": "bool",
+        "default": false
+      },
+      {
+        "key": "EnableSSN",
+        "display_name": "Social Security Numbers",
+        "help_text": "Conceal SSN Entries",
+        "type": "bool",
+        "default": false
       }
     ]
   }

--- a/plugin.json
+++ b/plugin.json
@@ -31,20 +31,6 @@
       {
         "key": "EnableMasterCard",
         "display_name": "MasterCard",
-        "type": "dropdown",
-        "help_text": "Conceal Mastercard Entries",
-        "default": "disabled",
-        "options": [{
-            "display_name": "disabled",
-            "value": "disabled" 
-        }, {
-            "display_name": "enabled",
-            "value": "Pattern: (?P<MasterCard](term>([Cc]ustomer [Oo]bsession)(?P<part1>5[1-5]\\d{2})[ -]?(?P<part2>\\d{4})[ -]?(?P<part3>\\d{4})[ -]?(?P<LastFour>[0-9]{4})) Template: MasterCard XXXX-XXXX-XXXX-$LastFour WordMatch: true"
-        }]
-      },
-      {
-        "key": "EnableMasterCardOld",
-        "display_name": "MasterCard",
         "help_text": "Conceal Mastercard Entries",
         "type": "bool",
         "default": false

--- a/server/autolink/autolink_test.go
+++ b/server/autolink/autolink_test.go
@@ -31,7 +31,9 @@ func setupTestPlugin(t *testing.T, l autolink.Autolink) *autolinkplugin.Plugin {
 	require.Nil(t, err)
 	p.UpdateConfig(func(conf *autolinkplugin.Config) {
 		conf.Links = []autolink.Autolink{l}
+		p.AddPreConfigLinks(conf)
 	})
+	fmt.Printf("p = %+v\n", p)
 	return p
 }
 
@@ -48,6 +50,36 @@ const (
 	replaceDiscover   = "Discover XXXX-XXXX-XXXX-$LastFour"
 	replaceAMEX       = "American Express XXXX-XXXXXX-X$LastFour"
 )
+
+func Test2CCRegex(t *testing.T) {
+	for _, tc := range []struct {
+		Name    string
+		RE      string
+		Replace string
+		In      string
+		Out     string
+	}{
+		{"Visa happy spaces", reVISA, replaceVISA, " abc 4111 1111 1111 1234 def", " abc VISA XXXX-XXXX-XXXX-1234 def"},
+		{"Visa happy dashes", reVISA, replaceVISA, "4111-1111-1111-1234", "VISA XXXX-XXXX-XXXX-1234"},
+		{"Visa happy mixed", reVISA, replaceVISA, "41111111 1111-1234", "VISA XXXX-XXXX-XXXX-1234"},
+		{"Visa happy digits", reVISA, replaceVISA, "abc 4111111111111234 def", "abc VISA XXXX-XXXX-XXXX-1234 def"},
+		{"Visa non-match start", reVISA, replaceVISA, "3111111111111234", ""},
+		{"Visa non-match num digits", reVISA, replaceVISA, " 4111-1111-1111-123", ""},
+		{"Visa non-match sep", reVISA, replaceVISA, "4111=1111=1111_1234", ""},
+		{"Visa non-match no break before", reVISA, replaceVISA, "abc4111-1111-1111-1234", "abcVISA XXXX-XXXX-XXXX-1234"},
+		{"Visa non-match no break after", reVISA, replaceVISA, "4111-1111-1111-1234def", "VISA XXXX-XXXX-XXXX-1234def"},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			re := regexp.MustCompile(tc.RE)
+			result := re.ReplaceAllString(tc.In, tc.Replace)
+			if tc.Out != "" {
+				assert.Equal(t, tc.Out, result)
+			} else {
+				assert.Equal(t, tc.In, result)
+			}
+		})
+	}
+}
 
 func TestCCRegex(t *testing.T) {
 	for _, tc := range []struct {

--- a/server/autolinkplugin/plugin_test.go
+++ b/server/autolinkplugin/plugin_test.go
@@ -367,6 +367,6 @@ func TestAPI(t *testing.T) {
 	p.ServeHTTP(&plugin.Context{SourcePluginId: "somthing"}, recorder, req)
 	resp := recorder.Result()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	require.Len(t, p.conf.Links, 2)
-	assert.Equal(t, "new", p.conf.Links[1].Name)
+	require.Len(t, p.conf.Links, 5)
+	assert.Equal(t, "VisaCard", p.conf.Links[1].Name)
 }


### PR DESCRIPTION
### Summary
This PR adds preconfigured autolinks to the plugin system console.  A sysadmin can enable or disable each without having to configure an autolink via the slash command.

### Notes for discussion

#### UI

I haven't seen a way to add a separator in the system console modal. This would be helpful to separate and label a section (ie. Preconfigured autolink section)

![image](https://user-images.githubusercontent.com/7575921/76587168-0b4ff580-64b1-11ea-9482-ac6164b56e62.png)

