### PR TITLE
Add DisableInHyperlinks to support more flexible use cases

### DIFF
--- a/server/autolink/autolink.go
+++ b/server/autolink/autolink.go
@@ -12,6 +12,7 @@ type Autolink struct {
 	Pattern              string   `json:"pattern"`
 	Template             string   `json:"template"`
 	Scope                []string `json:"scope"`
+	DisableInHyperlinks  bool     `json:"disableInHyperlinks"`
 	WordMatch            bool     `json:"wordmatch"`
 	DisableNonWordPrefix bool     `json:"disable_non_word_prefix"`
 	DisableNonWordSuffix bool     `json:"disable_non_word_suffix"`
@@ -29,6 +30,7 @@ func (l Autolink) Equals(x Autolink) bool {
 		l.Pattern != x.Pattern ||
 		len(l.Scope) != len(x.Scope) ||
 		l.Template != x.Template ||
+		l.DisableInHyperlinks != x.DisableInHyperlinks ||
 		l.WordMatch != x.WordMatch {
 		return false
 	}
@@ -54,8 +56,8 @@ func (l *Autolink) Compile() error {
 		return nil
 	}
 
-	// `\b` can be used with ReplaceAll since it does not consume characters,
-	// custom patterns can not and need to be processed one at a time.
+	// `\b` can be used with ReplaceAll since it does not consume characters.
+	// Custom patterns can not and need to be processed one at a time.
 	canReplaceAll := false
 	pattern := l.Pattern
 	template := l.Template
@@ -89,7 +91,7 @@ func (l *Autolink) Compile() error {
 	return nil
 }
 
-// Replace will subsitute the regex's with the supplied links
+// Replace will substitute the regexes with the supplied links
 func (l Autolink) Replace(message string) string {
 	if l.re == nil {
 		return message
@@ -149,6 +151,9 @@ func (l Autolink) ToMarkdown(i int) string {
 	if l.WordMatch {
 		text += fmt.Sprintf("  - WordMatch: `%v`\n", l.WordMatch)
 	}
+	if l.DisableInHyperlinks {
+		text += fmt.Sprintf("  - ApplyToHyperlinks: `%v`\n", l.DisableInHyperlinks)
+	}
 	return text
 }
 
@@ -163,6 +168,7 @@ func (l Autolink) ToConfig() map[string]interface{} {
 		"Scope":                l.Scope,
 		"DisableNonWordPrefix": l.DisableNonWordPrefix,
 		"DisableNonWordSuffix": l.DisableNonWordSuffix,
+		"DisableInHyperlinks":  l.DisableInHyperlinks,
 		"WordMatch":            l.WordMatch,
 		"Disabled":             l.Disabled,
 	}

--- a/server/autolinkplugin/plugin_test.go
+++ b/server/autolinkplugin/plugin_test.go
@@ -289,11 +289,14 @@ func TestSpecialCases(t *testing.T) {
 		Pattern:  "(Example)",
 		Template: "[Example](https://example.com)",
 	}, autolink.Autolink{
-		Pattern:  "MM-(?P<jira_id>\\d+)",
-		Template: "[MM-$jira_id](https://mattermost.atlassian.net/browse/MM-$jira_id)",
+		Pattern:             "MM-(?P<jira_id>\\d+)",
+		Template:            "[MM-$jira_id](https://mattermost.atlassian.net/browse/MM-$jira_id)",
+		WordMatch:           true,
+		DisableInHyperlinks: true,
 	}, autolink.Autolink{
-		Pattern:  "https://mattermost.atlassian.net/browse/MM-(?P<jira_id>\\d+)",
-		Template: "[MM-$jira_id](https://mattermost.atlassian.net/browse/MM-$jira_id)",
+		Pattern:   "https://mattermost.atlassian.net/browse/MM-(?P<jira_id>\\d+)",
+		Template:  "[MM-$jira_id](https://mattermost.atlassian.net/browse/MM-$jira_id)",
+		WordMatch: true,
 	}, autolink.Autolink{
 		Pattern:  "(foo!bar)",
 		Template: "fb",
@@ -453,6 +456,15 @@ func TestSpecialCases(t *testing.T) {
 		}, {
 			"check out MM-12345 too",
 			"check out [MM-12345](https://mattermost.atlassian.net/browse/MM-12345) too",
+		}, {
+			"also MM-12345, (MM-12345), MM-12345? :MM-12345.",
+			"also [MM-12345](https://mattermost.atlassian.net/browse/MM-12345), " +
+				"([MM-12345](https://mattermost.atlassian.net/browse/MM-12345)), " +
+				"[MM-12345](https://mattermost.atlassian.net/browse/MM-12345)? " +
+				":[MM-12345](https://mattermost.atlassian.net/browse/MM-12345).",
+		}, {
+			"you can look at https://some-other-system/ticket/MM-12345 if you want",
+			"you can look at https://some-other-system/ticket/MM-12345 if you want",
 		},
 	}
 


### PR DESCRIPTION
#### Summary
Adds a new property of links called `DisableInHyperlinks`, which makes it possible to properly support both link-insertion and link-shortening for a similar regex.

#### Details
Suppose we want to support the following patterns:
* `MM-12345` -> `[MM-12345](http://jira.server/MM-12345)`
* `http://jira.server/MM-12345` -> `[MM-12345](http://jira.server/MM-12345)`

If we do not enable `WordMatch` on the first pattern, then it fails in posts like `see MM-12345, or MM-23456`. Conversely if we do enable `WordMatch` on the first pattern, then it also gets inserted inside hyperlinks (completely breaking them).

Fundamentally, we never want the first pattern to be applied inside a hyperlink, so I added a flag to prevent that. Then, to deal with the fact that one pattern replacement may insert a new hyperlink, we also need to walk the markdown tree for each link pattern (not apply all link patterns inside one markdown tree traversal).

#### Possible alternative approaches

An alternative I quite like would be to add a `MatchHyperlink` flag instead. In that case, a `Link` with this flag is only allowed to match an *entire* hyperlink and replace it (in the expected use case, it would replace it with a formatted inline link). Conversely `Link`s without this flag set would not be allowed to match any part of an existing hyperlink. I think this is actually a more intuitive result - however, it would not preserve behaviour for existing plugin users, so some kind of migration support would be needed.

For interest: my original fork of this plugin went even further, replacing the `Link` general concept with two separate kinds of pattern spec, one which only inserts new hyperlinks (and by definition never matches inside a hyperlink) and one which only replaces hyperlinks with formatted inline links (and by definition never matches anything *except* a whole hyperlink). However I see from the test case coverage that this plugin, despite the name, is intended for any kind of text replacement. I wonder if it would be better to separate out link insertion (text -> link), link formatting (link -> inline link) and general text replacement more explicitly.