### PR TITLE
Remove json field names 

### DIFF
--- a/server/autolink/autolink.go
+++ b/server/autolink/autolink.go
@@ -7,14 +7,14 @@ import (
 
 // Autolink represents a pattern to autolink.
 type Autolink struct {
-	Name                 string   `json:"name"`
-	Disabled             bool     `json:"disabled"`
-	Pattern              string   `json:"pattern"`
-	Template             string   `json:"template"`
-	Scope                []string `json:"scope"`
-	WordMatch            bool     `json:"wordmatch"`
-	DisableNonWordPrefix bool     `json:"disable_non_word_prefix"`
-	DisableNonWordSuffix bool     `json:"disable_non_word_suffix"`
+	Name                 string
+	Disabled             bool
+	Pattern              string
+	Template             string
+	Scope                []string
+	WordMatch            bool
+	DisableNonWordPrefix bool
+	DisableNonWordSuffix bool
 
 	template      string
 	re            *regexp.Regexp


### PR DESCRIPTION
#### Summary
This PR will remove json field names in autolink struct.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-autolink/issues/115

