### PR TITLE
Match patterns in parentheses

### DIFF
--- a/server/autolink/autolink.go
+++ b/server/autolink/autolink.go
@@ -64,7 +64,7 @@ func (l *Autolink) Compile() error {
 			pattern = `\b` + pattern
 			canReplaceAll = true
 		} else {
-			pattern = `(?P<MattermostNonWordPrefix>(^|\s))` + pattern
+			pattern = `(?P<MattermostNonWordPrefix>(^|[\s\(]))` + pattern
 			template = `${MattermostNonWordPrefix}` + template
 		}
 	}


### PR DESCRIPTION
Add matching opening parenthesis to the non-word pattern prefix. Closing parenthesis has already been there.