### PR TITLE
Enable slash command by default

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -21,7 +21,7 @@
         "key": "EnableAdminCommand",
         "display_name": "Enable administration with /autolink command",
         "type": "bool",
-        "default": false
+        "default": true
       },
       {
         "key": "EnableOnUpdate",


### PR DESCRIPTION
#### Summary
Given that in Cloud the slash command are the only way to configure the plugin, we should enabled it by default. The feature has soaked for long enough. 

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-autolink/issues/137
