### PR TITLE
Update CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,18 @@ orbs:
 
 workflows:
   version: 2
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - plugin-ci/lint
+      - plugin-ci/test
+      - plugin-ci/build
   ci:
     jobs:
       - plugin-ci/lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,17 +28,6 @@ workflows:
             - plugin-ci/lint
             - plugin-ci/coverage
             - plugin-ci/build
-      - plugin-ci/deploy-release:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-          context: plugin-ci
-          requires:
-            - plugin-ci/lint
-            - plugin-ci/coverage
-            - plugin-ci/build
       - plugin-ci/deploy-release-github:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-      - plugin-ci/coverage:
+      - plugin-ci/test:
           filters:
             tags:
               only: /^v.*/
@@ -19,6 +19,9 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - plugin-ci/coverage:
+          requires:
+            - plugin-ci/test
       - plugin-ci/deploy-ci:
           filters:
             branches:
@@ -26,7 +29,7 @@ workflows:
           context: plugin-ci
           requires:
             - plugin-ci/lint
-            - plugin-ci/coverage
+            - plugin-ci/test
             - plugin-ci/build
       - plugin-ci/deploy-release-github:
           filters:
@@ -37,5 +40,5 @@ workflows:
           context: matterbuild-github-token
           requires:
             - plugin-ci/lint
-            - plugin-ci/coverage
+            - plugin-ci/test
             - plugin-ci/build


### PR DESCRIPTION
#### Summary
- Drop plugin-ci/deploy-release
- Add test job: `coverage` does require `test` because if `test` fails `coverage` will surely also fail
- Add nighly job

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-autolink/issues/136

