### PR TITLE
Slash-commands now look for exact match

### DIFF
--- a/server/autolinkplugin/command.go
+++ b/server/autolinkplugin/command.go
@@ -336,7 +336,7 @@ func searchLinkRef(p *Plugin, requireUnique bool, args ...string) ([]autolink.Au
 
 	found := []int{}
 	for i, l := range links {
-		if strings.Contains(l.Name, args[0]) {
+		if strings.Compare(l.Name, args[0]) == 0 {
 			found = append(found, i)
 		}
 	}


### PR DESCRIPTION
#### Summary

The pull request fixes the issue where `/autolink [command]` doesn't look for exact match when manipulating links. 

However, the current implementation might be too naive, because it'll affect all commands and not just those that manipulate links, so I'd appreciate feedback if that is desirable or not, otherwise I'll need to give more thought to how to fix this only for specific commands.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-autolink/issues/138

