### PR TITLE
Fixed setting Mattermost-Plugin-ID header

### DIFF
--- a/server/autolinkplugin/plugin.go
+++ b/server/autolinkplugin/plugin.go
@@ -217,7 +217,7 @@ func (p *Plugin) ProcessPost(c *plugin.Context, post *model.Post) (*model.Post, 
 }
 
 func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
-	r.Header.Add("Mattermost-Plugin-ID", c.SourcePluginId)
+	r.Header.Set("Mattermost-Plugin-ID", c.SourcePluginId)
 	p.handler.ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
#### Summary
`Mattermost-Plugin-ID` header was `Add`ed, not `Set` in the request headers, resulting in a vulnerability.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34892

- Note: @srkgupta @crspeller is this vulnerability present in other plugins? Also, 1/5 we should probably handle `Mattermost-Plugin-ID` on the server since most plugins use `mux` and the handlers don't have access to `plugin.Context` easily.
- Note: @catalintomai @iomodo @aaronrothschild we'll need a new release for this.