### PR TITLE
[MM-34926] Short-circuit link processing if the regex is non-terminal

### DIFF
--- a/server/autolink/autolink.go
+++ b/server/autolink/autolink.go
@@ -108,6 +108,12 @@ func (l Autolink) Replace(message string) string {
 		if submatch == nil {
 			break
 		}
+
+		// The beginning of the submatch is equal to the end of the submatch here. The regex pattern is non-terminal.
+		if len(submatch) > 1 && submatch[0] == submatch[1] {
+			break
+		}
+
 		out = append(out, in[:submatch[0]]...)
 		out = l.re.Expand(out, []byte(l.template), in, submatch)
 		in = in[submatch[1]:]

--- a/server/autolink/autolink.go
+++ b/server/autolink/autolink.go
@@ -104,13 +104,12 @@ func (l Autolink) Replace(message string) string {
 	in := []byte(message)
 	out := []byte{}
 	for {
-		submatch := l.re.FindSubmatchIndex(in)
-		if submatch == nil {
+		if len(in) == 0 {
 			break
 		}
 
-		// The beginning of the submatch is equal to the end of the submatch here. The regex pattern is non-terminal.
-		if len(submatch) > 1 && submatch[0] == submatch[1] {
+		submatch := l.re.FindSubmatchIndex(in)
+		if submatch == nil {
 			break
 		}
 

--- a/server/autolink/autolink_test.go
+++ b/server/autolink/autolink_test.go
@@ -3,6 +3,7 @@ package autolink_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
@@ -318,5 +319,50 @@ func TestEquals(t *testing.T) {
 			eq := tc.l1.Equals(tc.l2)
 			assert.Equal(t, tc.expectEqual, eq)
 		})
+	}
+}
+
+func TestWildcard(t *testing.T) {
+	for _, tc := range []struct {
+		Name string
+		Link autolink.Autolink
+	}{
+		{
+			Name: ".*",
+			Link: autolink.Autolink{
+				Pattern:  ".*",
+				Template: "My template",
+			},
+		},
+		{
+			Name: ".*.",
+			Link: autolink.Autolink{
+				Pattern:  ".*.",
+				Template: "My template",
+			},
+		},
+	} {
+		p := setupTestPlugin(t, tc.Link)
+
+		message := "Your message"
+
+		var post *model.Post
+		done := make(chan bool)
+		go func() {
+			post, _ = p.MessageWillBePosted(nil, &model.Post{
+				Message: message,
+			})
+
+			done <- true
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(1 * time.Millisecond):
+			panic("wildcard regex timed out")
+		}
+
+		assert.NotNil(t, post, "post is nil")
+		assert.Equal(t, "My template", post.Message)
 	}
 }


### PR DESCRIPTION
#### Summary

When the autolink's pattern contains `.*`, the process indefinitely hangs due to continuously processing an empty non-nil match. https://github.com/mattermost/mattermost-plugin-autolink/pull/166#discussion_r675118216

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-34926