### PR TITLE
Fix Autolink admin config parsing

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -21,19 +21,19 @@
     "header": "Configure this plugin directly in the `config.json` file, or using the `/autolink` command. Learn more [in our documentation](https://github.com/mattermost/mattermost-plugin-autolink/blob/master/README.md).\n\n To report an issue, make a suggestion, or contribute, [check the plugin repository](https://github.com/mattermost/mattermost-plugin-autolink).",
     "settings": [
       {
-        "key": "EnableAdminCommand",
+        "key": "enableadmincommand",
         "display_name": "Enable administration with /autolink command:",
         "type": "bool",
         "default": true
       },
       {
-        "key": "EnableOnUpdate",
+        "key": "enableonupdate",
         "display_name": "Apply plugin to updated posts as well as new posts:",
         "type": "bool",
         "default": false
       },
       {
-        "key": "PluginAdmins",
+        "key": "pluginadmins",
         "display_name": "Admin User IDs:",
         "type": "text",
         "help_text": "Comma-separated list of user IDs authorized to administer the plugin in addition to the System Admins.\n \n User IDs can be found by navigating to **System Console > User Management > Users**."

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -2,10 +2,10 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-plugin-autolink/server/autolink"
 )
@@ -90,7 +90,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) setLink(w http.ResponseWriter, r *http.Request) {
 	var newLink autolink.Autolink
 	if err := json.NewDecoder(r.Body).Decode(&newLink); err != nil {
-		h.handleError(w, fmt.Errorf("unable to decode body: %w", err))
+		h.handleError(w, errors.Wrap(err, "unable to decode body"))
 		return
 	}
 
@@ -114,7 +114,7 @@ func (h *Handler) setLink(w http.ResponseWriter, r *http.Request) {
 	status := http.StatusNotModified
 	if changed {
 		if err := h.store.SaveLinks(links); err != nil {
-			h.handleError(w, fmt.Errorf("unable to save link: %w", err))
+			h.handleError(w, errors.Wrap(err, "unable to save link"))
 			return
 		}
 		status = http.StatusOK

--- a/server/autolink/autolink.go
+++ b/server/autolink/autolink.go
@@ -7,14 +7,14 @@ import (
 
 // Autolink represents a pattern to autolink.
 type Autolink struct {
-	Name                 string
-	Disabled             bool
-	Pattern              string
-	Template             string
-	Scope                []string
-	WordMatch            bool
-	DisableNonWordPrefix bool
-	DisableNonWordSuffix bool
+	Name                 string   `json:"Name"`
+	Disabled             bool     `json:"Disabled"`
+	Pattern              string   `json:"Pattern"`
+	Template             string   `json:"Template"`
+	Scope                []string `json:"Scope"`
+	WordMatch            bool     `json:"WordMatch"`
+	DisableNonWordPrefix bool     `json:"DisableNonWordPrefix"`
+	DisableNonWordSuffix bool     `json:"DisableNonWordSuffix"`
 
 	template      string
 	re            *regexp.Regexp
@@ -155,20 +155,4 @@ func (l Autolink) ToMarkdown(i int) string {
 		text += fmt.Sprintf("  - WordMatch: `%v`\n", l.WordMatch)
 	}
 	return text
-}
-
-// ToConfig returns a JSON-encodable Link represented solely with map[string]
-// interface and []string types, compatible with gob/RPC, to be used in
-// SavePluginConfig
-func (l Autolink) ToConfig() map[string]interface{} {
-	return map[string]interface{}{
-		"Name":                 l.Name,
-		"Pattern":              l.Pattern,
-		"Template":             l.Template,
-		"Scope":                l.Scope,
-		"DisableNonWordPrefix": l.DisableNonWordPrefix,
-		"DisableNonWordSuffix": l.DisableNonWordSuffix,
-		"WordMatch":            l.WordMatch,
-		"Disabled":             l.Disabled,
-	}
 }

--- a/server/autolinkplugin/command.go
+++ b/server/autolinkplugin/command.go
@@ -392,7 +392,13 @@ func parseBoolArg(arg string) (bool, error) {
 func saveConfigLinks(p *Plugin, links []autolink.Autolink) error {
 	conf := p.getConfig()
 	conf.Links = links
-	appErr := p.API.SavePluginConfig(conf.ToConfig())
+
+	configMap, err := p.getConfig().ToMap()
+	if err != nil {
+		return err
+	}
+
+	appErr := p.API.SavePluginConfig(configMap)
 	if appErr != nil {
 		return appErr
 	}

--- a/server/autolinkplugin/plugin.go
+++ b/server/autolinkplugin/plugin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin"
 	"github.com/mattermost/mattermost-server/v6/shared/markdown"
+	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-plugin-autolink/server/api"
 )
@@ -39,8 +40,7 @@ func (p *Plugin) OnActivate() error {
 func (p *Plugin) IsAuthorizedAdmin(userID string) (bool, error) {
 	user, err := p.API.GetUser(userID)
 	if err != nil {
-		return false, fmt.Errorf(
-			"failed to obtain information about user `%s`: %w", userID, err)
+		return false, errors.Wrapf(err, "failed to obtain information about user `%s`", userID)
 	}
 	if strings.Contains(user.Roles, "system_admin") {
 		p.API.LogInfo(

--- a/server/autolinkplugin/plugin_test.go
+++ b/server/autolinkplugin/plugin_test.go
@@ -258,7 +258,12 @@ func (suite *SuiteAuthorization) TestNonExistantUsersAreIgnored() {
 	}
 	suite.adminUsernames = "marynaId,karynaId"
 
-	suite.api.On("LogError", mock.AnythingOfType("string")).Return(nil)
+	suite.api.On("LogWarn", mock.AnythingOfType("string"),
+		"userID",
+		"karynaId",
+		"error",
+		mock.AnythingOfType("*model.AppError"),
+	).Return(nil)
 	suite.api.On("LogInfo", mock.AnythingOfType("string")).Return(nil)
 
 	p := New()


### PR DESCRIPTION
#### Summary
The plugin was falsely storing it's config in UperCase names, which lead to the webapp not being able to rea

This PR make use of `json.Marshal` to convert the plugin config to an `map[string]Interface{}` and hence json tags are used everywhere now.

There is one migration left. If an admin (after updating to this PR) sees the empty list in the system console and inputs something, the existing admin list will be overwritten. Running `/autolink add` or `/autolink delete` brings the configuration in the right state again. 

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-autolink/issues/180
https://github.com/mattermost/mattermost-plugin-autolink/issues/181

