### PR TITLE
[GH-208] Add feedback if the list link is empty

### DIFF
--- a/server/autolinkplugin/command.go
+++ b/server/autolinkplugin/command.go
@@ -119,6 +119,9 @@ func executeList(p *Plugin, c *plugin.Context, header *model.CommandArgs, args .
 			text += links[i].ToMarkdown(i + 1)
 		}
 	} else {
+		if len(links) == 0 {
+			text += "There are no links to list"
+		}
 		for i, l := range links {
 			text += l.ToMarkdown(i + 1)
 		}


### PR DESCRIPTION
Add feedback if the list link is empty
Fixes https://github.com/mattermost/mattermost-plugin-autolink/issues/208

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

